### PR TITLE
Made the cards width inside the background image

### DIFF
--- a/style.css
+++ b/style.css
@@ -338,3 +338,38 @@ a {
     font-weight: 400;
     font-family: 'Poppins';
 }
+.days-container {
+    display: flex;
+    flex-wrap: wrap;          /* Wrap to next line if needed */
+    justify-content: space-between; /* Evenly space cards */
+    gap: 20px;                /* Optional, extra spacing */
+    max-width: 1300px;        /* Matches gallery width */
+    margin: 0 auto;           /* Center the container */
+    padding: 0 20px;          /* Avoid touching edges */
+    box-sizing: border-box;
+}
+
+@media (max-width: 1024px) {
+    .day-card {
+        flex: 1 1 calc(33.33% - 20px); /* 3 cards per row */
+    }
+}
+
+@media (max-width: 768px) {
+    .day-card {
+        flex: 1 1 calc(50% - 20px); /* 2 cards per row */
+    }
+}
+
+@media (max-width: 480px) {
+    .day-card {
+        flex: 1 1 100%; /* 1 card per row */
+    }
+}
+.day-card {
+    padding: 15px;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    flex: 1 1 180px;          /* Minimum width for responsiveness */
+    box-sizing: border-box;
+}


### PR DESCRIPTION
## Description

This PR fixes the layout issue in the "Five Days of Celebration" section where the day cards were overflowing beyond the gallery image boundary and appearing uneven on the right side. The update ensures:

- Cards are evenly spaced using flex layout.
- Minimum width is maintained for responsiveness.
- The container aligns with the gallery images and remains centered.
- The section works well on all screen sizes.

Closes #2 

## Changes Made

- Updated .days-container CSS to include flex-wrap, justify-content: space-between, and proper padding.
- Simplified .day-card CSS to maintain even spacing and minimum width without disappearing cards.

## How to Test

- Open the homepage or the Durga Puja page.
- Scroll to the "Five Days of Celebration" section.
- Confirm that all cards are visible, evenly spaced, and aligned within the gallery boundary.

## Screenshot
<img width="1919" height="864" alt="image" src="https://github.com/user-attachments/assets/a5803147-c45e-409e-bee8-5a4390027807" />
